### PR TITLE
Added a {switch} example for Grid Fields inside a Fluid Field loop.

### DIFF
--- a/source/fieldtypes/fluid.rst
+++ b/source/fieldtypes/fluid.rst
@@ -195,6 +195,22 @@ this_field_name
 
 Alias of ``:current_field_name``.
 
+switch
+------
+
+When a Grid Field is inside a Fluid Field loop, the ``{switch}`` syntax is a little different when using this variable in a stand-alone :doc:`Grid Field </fieldtypes/grid>`.
+
+::
+
+  {fluid_field:grid_field}
+    {content}
+      <div class="{content:switch='odd|even'}">
+        ...
+      </div>
+    {/content}
+  {/fluid_field:grid_field}
+
+
 this_fieldtype
 --------------
 


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Per Issue #9, added a simple code example of a {switch} statement inside a Fluid Field's Grid Field. Reasoning: The syntax is a little different when a Grid Field is inside a Fluid Field loop:
{content:switch='odd|even'] as opposed to a stand-along Grid Field: {grid_field_name:switch='odd|even'}.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#9](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/issues/9).

## Nature of This Change

Added `{switch}` code example in the Fieldtypes/Fluid #Variables section.

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
<!-- Required when this is associated with an application pull request -->

<!-- If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine-User-Guide

Thank you for contributing to the ExpressionEngine User Guide! -->