### PR TITLE
Change caption to description

### DIFF
--- a/source/add-ons/file/file_tag.rst
+++ b/source/add-ons/file/file_tag.rst
@@ -34,8 +34,8 @@ Here is a simple example of a possible usage of this tag::
       {category_image} - <a href="{path='about/test'}">{category_name}</a><br>
     {/categories}
 
-    {if medium_file_url}
-      <p><a href="{id_path='gallery/comments'}"><img src="{medium_file_url}" width="{medium_width}" height="{medium_height}" alt="{title}" title="{title}" /></a></p>
+    {if url:small}
+      <p><a href="{id_path='gallery/comments'}"><img src="{url:small}" width="{width:small}" height="{width:small}" alt="{title}" title="{title}" /></a></p>
     {/if}
 
     {description}

--- a/source/add-ons/file/file_tag.rst
+++ b/source/add-ons/file/file_tag.rst
@@ -38,7 +38,7 @@ Here is a simple example of a possible usage of this tag::
       <p><a href="{id_path='gallery/comments'}"><img src="{medium_file_url}" width="{medium_width}" height="{medium_height}" alt="{title}" title="{title}" /></a></p>
     {/if}
 
-    {caption}
+    {description}
   {/exp:file:entries}
 
 Parameters
@@ -470,7 +470,7 @@ second will use "option_two", the third "option_three", the fourth
 The most straightforward use for this would be to alternate colors. It
 could be used like so::
 
-  {exp:file:entries} <div class="{switch="one|two"}"> <h1>{filename}</h1> {caption} </div> {/exp:file:entries}
+  {exp:file:entries} <div class="{switch="one|two"}"> <h1>{filename}</h1> {description} </div> {/exp:file:entries}
 
 The entries would then alternate between <div class="one"> and <div
 class="two">.


### PR DESCRIPTION
<!-- What's in this pull request? -->
Closes #13

## Overview
The example uses {caption} which isn't in the list of variables. While {caption} is supported https://github.com/ExpressionEngine/ExpressionEngine/blob/stability/system/ee/EllisLab/Addons/file/mod.file.php#L448 for backwards compatibility this should be {description}

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves #13

## Nature of This Change

<!-- Check all that apply: -->

- [x ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code
