### PR TITLE
Update to example text for trimmed_url

### DIFF
--- a/docs/channels/entries.md
+++ b/docs/channels/entries.md
@@ -1077,7 +1077,7 @@ The total number of entries being displayed.
 
 ### `{trimmed_url}`
 
-The domain name for your site, trimmed of any subdomains. For instance, example.com becomes example.com. Typically only used in the Atom feed Template.
+The domain name for your site, trimmed of any subdomains. For instance, beta.example.com becomes example.com. Typically only used in the Atom feed Template.
 
 ### `{url_title}`
 


### PR DESCRIPTION
Because the example didn't make sense.

<!-- What's in this pull request? -->
## Overview

Small fix to trimmed_url example text.
