### PR TITLE
Fixing minor typo

### DIFF
--- a/docs/development/legacy/libraries/email.md
+++ b/docs/development/legacy/libraries/email.md
@@ -36,7 +36,7 @@ The Email class will automatically create all email headers and will process the
     ee()->email->to($recipient);
     ee()->email->subject($email_subject);
     ee()->email->message(entities_to_ascii($email_msg));
-    ee()->email->Send();
+    ee()->email->send();
 
 ### Properties
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Just a simple text change. The email send function was capitalized. This just makes it lowercase. 

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [X] 🛁 Rewrites existing documentation
- [X] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code