### PR TITLE
Update Documentation for Attribute Pass-Through forms

### DIFF
--- a/docs/add-ons/consent.md
+++ b/docs/add-ons/consent.md
@@ -38,6 +38,8 @@ Consent Forms allow the visitor to grant or withdraw consent to one or more Cons
 
 ## Parameters
 
+The Consent Form Tag will create an HTML form and include within its opening tag the minimum attributes necessary for it to work.  If you need additional attributes to be specified, The Simple Search Form Tag allows you to specify these attributes as additional parameters within the tag itself.  See the entry for [pass_through_attributes](#pass_through_attributes) in the parameter listing for more information.
+
 [TOC=3]
 
 ### `consent=`
@@ -63,6 +65,16 @@ Specify the HTML `class=` attribute.
     form_id='consent_form'
 
 Specify the HTML `id=` attribute.
+
+### `pass through attributes`
+
+    data-automobile_type="buick" role="search" name="some name"
+
+You can include in your tag a parameter with a name identical to any valid [HTML Form}(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) attribute, any [HTML Global Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes), or the [ARIA Search role attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role).  
+
+If you assign a value to your parameter the value will be assigned to the attribute in the completed Form tag.  To include an attribute which does not take a value (e.g. `novalidate`) you need to define a null value for the parameter (i.e. `novalidate=""`).
+
+If you specify a parameter with a name that is the same as an attribute already being set by Consent Form, the parameter value you enter will be ignored.
 
 ### `return=`
 

--- a/docs/add-ons/email.md
+++ b/docs/add-ons/email.md
@@ -54,6 +54,9 @@ The contact form is created similar to a standard web form, only you **do not** 
 
 ## Parameters
 
+The Email Contact Form Tag will create an HTML form and include within its opening tag the minimum attributes necessary for it to work.  If you need additional attributes to be specified, The Simple Search Form Tag allows you to specify these attributes as additional parameters within the tag itself.  See the entry for [pass_through_attributes](#pass_through_attributes) in the parameter listing for more information.
+
+
 [TOC=3]
 
 ### `charset=`
@@ -67,6 +70,16 @@ This allows you to set the character set of the email being sent. Use this if yo
     name="myForm"
 
 This allows you to set a name= attribute for the form. Keep in mind that name= is deprecated in XHTML.
+
+### `pass through attributes`
+
+    data-automobile_type="buick" role="search" name="some name"
+
+You can include in your tag a parameter with a name identical to any valid [HTML Form}(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) attribute, any [HTML Global Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes), or the [ARIA Search role attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role).  
+
+If you assign a value to your parameter the value will be assigned to the attribute in the completed Form tag.  To include an attribute which does not take a value (e.g. `novalidate`) you need to define a null value for the parameter (i.e. `novalidate=""`).
+
+If you specify a parameter with a name that is the same as an attribute already being set by the Email Contact Form tag, the parameter value you enter will be ignored.
 
 ### `recipients=`
 

--- a/docs/add-ons/search/advanced.md
+++ b/docs/add-ons/search/advanced.md
@@ -141,6 +141,8 @@ The search results are displayed on the page you specify as the [result_page=](#
 
 ## Parameters
 
+The Advanced Search Form Tag will create an HTML form and include within its opening tag the minimum attributes necessary for it to work.  If you need additional attributes to be specified, The Advanced Search Form Tag allows you to specify these attributes as additional parameters within the tag itself.  See the entry for [pass_through_attributes](#pass_throug_attributes) in the parameter listing for more information.
+
 [TOC=3]
 
 ### `category=`
@@ -176,6 +178,16 @@ Specify the name attribute for the &lt;form&gt; tag, which will allow you to spe
     no_result_page="search/noresults"
 
 You may specify a particular Template to display in the case when there are no results. This takes a standard "Template_Group/Template" as input.
+
+### `pass through attributes`
+
+    data-automobile_type="buick" role="search" name="some name"
+
+You can include in your tag a parameter with a name identical to any valid [HTML Form}(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) attribute, any [HTML Global Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes), or the [ARIA Search role attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role).  
+
+If you assign a value to your parameter the value will be assigned to the attribute in the completed Form tag.  To include an attribute which does not take a value (e.g. `novalidate`) you need to define a null value for the parameter (i.e. `novalidate=""`).
+
+If you specify a parameter with a name that is the same as an attribute already being set by the Advanced Search Form tag, the parameter value you enter will be ignored.
 
 ### `result_page=`
 

--- a/docs/add-ons/search/simple.md
+++ b/docs/add-ons/search/simple.md
@@ -73,6 +73,9 @@ Besides specifying whether future entries are included in the search using the [
 
 ## Parameters
 
+The Simple Search Form Tag will create an HTML form and include within its opening tag the minimum attributes necessary for it to work.  If you need additional attributes to be specified, The Simple Search Form Tag allows you to specify these attributes as additional parameters within the tag itself.  See the entry for [pass_through_attributes](#pass_through_attributes) in the parameter listing for more information.
+
+
 ### `name=`
 
     name="search_form"
@@ -84,6 +87,16 @@ Specify the name attribute for the &lt;form&gt; tag, which will allow you to spe
     no_result_page="search/noresults"
 
 You may specify a particular Template to display in the case when there are no results. This takes a standard "Template_Group/Template" as input.
+
+### `pass through attributes`
+
+    data-automobile_type="buick" role="search" name="some name"
+
+You can include in your tag a parameter with a name identical to any valid [HTML Form}(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) attribute, any [HTML Global Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes), or the [ARIA Search role attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role).  
+
+If you assign a value to your parameter the value will be assigned to the attribute in the completed Form tag.  To include an attribute which does not take a value (e.g. `novalidate`) you need to define a null value for the parameter (i.e. `novalidate=""`).
+
+If you specify a parameter with a name that is the same as an attribute already being set by the Simple Search Form tag, the parameter value you enter will be ignored.
 
 ### `result_page=`
 

--- a/docs/channels/channel-form/overview.md
+++ b/docs/channels/channel-form/overview.md
@@ -61,7 +61,9 @@ By default, validation errors will be displayed using the User Message Template.
 
 [TOC=3 hide]
 
-The Following parameters are available for the `{exp:channel:form}`:
+The Channel Form tag will create an HTML form and include within its opening tag the minimum attributes necessary for it to work.  If you need additional attributes to be specified, Channel Form allows you to specify these attributes as additional parameters within the tag itself.  See the entry for [pass_through_attributes](#pass_through_attributes) in the parameter listing for more information.
+
+The following parameters are available for the `{exp:channel:form}`:
 
 ### `allow_comments=`
 
@@ -156,6 +158,16 @@ Output your results in JSON format, instead of performing a redirect.
     logged_out_member_id="3"
 
 In order to allow logged out users to use the entry form, you must specify a member_id which will be used as the author of the entry.
+
+### `pass through attributes`
+
+    data-automobile_type="buick" role="search" name="some name"
+
+You can include in your tag a parameter with a name identical to any valid [HTML Form}(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) attribute, any [HTML Global Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes), or the [ARIA Search role attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role).  
+
+If you assign a value to your parameter the value will be assigned to the attribute in the completed Form tag.  To include an attribute which does not take a value (e.g. `novalidate`) you need to define a null value for the parameter (i.e. `novalidate=""`).
+
+If you specify a parameter with a name that is the same as an attribute already being set by the Channel Form tag, the parameter value you enter will be ignored.
 
 ### `require_entry=`
 

--- a/docs/member/index.md
+++ b/docs/member/index.md
@@ -72,6 +72,8 @@ Here is how you might use the tag:
 
 ### Parameters
 
+The Login Form Tag will create an HTML form and include within its opening tag the minimum attributes necessary for it to work.  If you need additional attributes to be specified, The Simple Search Form Tag allows you to specify these attributes as additional parameters within the tag itself.  See the entry for [pass_through_attributes](#pass_through_attributes) in the parameter listing for more information.
+
 [TOC=4]
 
 #### `action=`
@@ -97,6 +99,17 @@ This parameter allows you to specify the id attribute for the &lt;form&gt; tag.
     form_name="login"
 
 This parameter allows you to specify a name attribute for the &lt;form&gt; tag.
+
+### `pass through attributes`
+
+    data-automobile_type="buick" role="search" name="some name"
+
+You can include in your tag a parameter with a name identical to any valid [HTML Form}(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) attribute, any [HTML Global Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes), or the [ARIA Search role attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role).  
+
+If you assign a value to your parameter the value will be assigned to the attribute in the completed Form tag.  To include an attribute which does not take a value (e.g. `novalidate`) you need to define a null value for the parameter (i.e. `novalidate=""`).
+
+If you specify a parameter with a name that is the same as an attribute already being set by the Login Form tag, the parameter value you enter will be ignored.
+
 
 #### `return=`
 


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (release/next-minor) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

These documentation edits complement the proposed changes to the `form_declaration` function in `Functions.php`

They provide updated instructions concerning how to 'pass through' FORM attributes via tag parameters.

The pass through function is available to any tag that uses the form_declaration function to draw its opening `<FORM>` tag.  I think all the cases covered by this are included in this documentation update: AFAIK the `Comment` form does not use this function and so does not benefit from these changes.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#441](https://github.com/ExpressionEngine/ExpressionEngine/issues/441).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [X] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
<!-- Required when this is associated with an application pull request -->
Application Pull Request: https://github.com/ExpressionEngine/ExpressionEngine/pull/443

<!-- If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine-User-Guide

Thank you for contributing to the ExpressionEngine User Guide! -->
