### PR TITLE
Without adding this class "fieldset-faux" the "Add Row" does not work

### DIFF
--- a/docs/development/services/table.md
+++ b/docs/development/services/table.md
@@ -292,3 +292,5 @@ If you're using the [Shared Form View](development/shared-form-view.md), your fi
 Note we're setting `wide` to denote the field should take up the entire width of the form, and `grid` so the form display logic can do the necessary markup tweaks for proper styling and behavior of the Grid.
 
 For those not using the Shared Form View, make sure your Grid is in a div tag instead of a fieldset tag and make sure it has a class of `grid-publish`.
+
+Note: We must need to add "fieldset-faux" class as parent to the grid structure.


### PR DESCRIPTION
We must need a "fieldset-faux" class for the created grid structure. Without adding this class, then the "Add Row" button is not worked in the grid for CP/Table service.

More detail is added in the bug https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/issues/94

<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Replace this paragraph with a description of your changes and reasoning. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
<!-- Required when this is associated with an application pull request -->
Application Pull Request: https://github.com/ExpressionEngine/ExpressionEngine/pulls/NNN

<!-- If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine-User-Guide

Thank you for contributing to the ExpressionEngine User Guide! -->
