### PR TITLE
Remove old link

### DIFF
--- a/docs/control-panel/settings/content-design.md
+++ b/docs/control-panel/settings/content-design.md
@@ -33,8 +33,8 @@ Set whether to assign an entry to both the selected category and its parent cate
 
 This is where you indicate which resizing protocol to use. You may need to contact your Host or server admin to determine which protocols are installed and available on your server. The options are:
 
-- [GD](http://www.boutell.com/gd/)
-- [GD 2](http://www.boutell.com/gd/)
+- [GD](https://www.php.net/manual/en/intro.image.php)
+- [GD 2](https://www.php.net/manual/en/intro.image.php)
 - [ImageMagick](http://www.imagemagick.org/script/index.php)
 - [NetPBM](http://netpbm.sourceforge.net/)
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Old links redirected to `https://www.boutell.co.uk/short-term-loans/` which definitely didn't seem like image manipulation software. A little bit of searching led me to the basic library PHP has been using.

These links in the docs go at least as far back as Version 3. I don't think Version 2 has this setting (at least I never noticed it before we upgraded to V5) so I wouldn't know where to find it in the docs if it existed.

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [X] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

<!-- If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine-User-Guide

Thank you for contributing to the ExpressionEngine User Guide! -->

P.S. I couldn't sign the contributor license agreement since the site can't be found. Tried Cloudflare's, Google's, and my ISP's DNS. In general, I'm sure I'll agree.
