### PR TITLE
Update addon-installer.md

### DIFF
--- a/docs/development/addon-installer.md
+++ b/docs/development/addon-installer.md
@@ -89,14 +89,12 @@ Additional functionality can be installed using the following guidelines:
 
         public function install()
         {
-            parent::install();
-            return TRUE;
+            return parent::install();
         }
 
-        public function uninstall ()
+        public function uninstall()
         {
-            parent::uninstall();
-            return TRUE;
+            return parent::uninstall();
         }
 
     }

--- a/docs/development/addon-installer.md
+++ b/docs/development/addon-installer.md
@@ -62,8 +62,8 @@ Additional functionality can be installed using the following guidelines:
         public $methods = [
             [
                 'method' => 'run', // will default to same as hook if not defined
-                'hook' => 'template_fetch_template' // required
-                'priority' => ""
+                'hook' => 'template_fetch_template', // required
+                'priority' => "",
                 'enabled' => "" // y/n
             ],
             [
@@ -90,11 +90,13 @@ Additional functionality can be installed using the following guidelines:
         public function install()
         {
             parent::install();
+            return TRUE;
         }
 
         public function uninstall ()
         {
             parent::uninstall();
+            return TRUE;
         }
 
     }
@@ -113,8 +115,8 @@ Extension files can now be as simplified as well. However they must include the 
         public $methods = [
             [
                 'method' => 'run', // will default to same as hook if not defined
-                'hook' => 'template_fetch_template' // required
-                'priority' => ""
+                'hook' => 'template_fetch_template', // required
+                'priority' => "",
                 'enabled' => "" // y/n
             ],
             [
@@ -147,8 +149,8 @@ Additionally you may use `activate_extension()` and `disable_extension()` if nee
         public $methods = [
             [
                 'method' => 'run', // will default to same as hook if not defined
-                'hook' => 'template_fetch_template' // required
-                'priority' => ""
+                'hook' => 'template_fetch_template', // required
+                'priority' => "",
                 'enabled' => "" // y/n
             ],
             [


### PR DESCRIPTION
## Overview

**First**: Addons now extend the `Installer` class, which takes advantage of array data in the `upd.addon.php` and `ext.addon.php` files. These two arrays, `actions` and `methods`, were missing commas. I added the commas to allow easy copy and paste straight into PHP.

**Second**: The addon installer class methods, `Query_upd::install()` and `Query_upd::uninstall()`, requires you to return a boolean to indicate whether or not the addons was installed properly. So, I added `return TRUE` to both of these methods.

<!-- Check all that apply: -->

- [ x ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ x ] 🛁 Rewrites existing documentation
- [ x ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code
