### PR TITLE
Corrected information about CAPTCHA preferences

### DIFF
--- a/docs/add-ons/email.md
+++ b/docs/add-ons/email.md
@@ -179,7 +179,7 @@ The CAPTCHA input for the form. It is usually used with a conditional so that it
         <p>{captcha}<br /> <input type="text" name="captcha" value="" maxlength="20" /></p>
     {/if}
 
-The setting to disable or enable CAPTCHA for the contact form can be found in the [Email Configuration](control-panel/settings/email.md) preferences.
+The setting to disable or enable CAPTCHA is applied based on the [CAPTCHA preferences](control-panel/settings/captcha.md) for all of your site's front end forms.
 
 ### `from`
 

--- a/docs/comment/form.md
+++ b/docs/comment/form.md
@@ -109,7 +109,7 @@ If this parameter is not defined, they will be returned to the form page.
 
 #### `{if captcha}`
 
-As noted in the [captcha section](security/captchas.md), the contents of the conditional ({if captcha}) tag will only appear if you have the CAPTCHA preference turned on for comments in the channel the entry is associated with.
+As noted in the [captcha section](security/captchas.md), the contents of the conditional ({if captcha}) tag will only appear if you have the CAPTCHA preference turned on for front-end forms, although it can be disabled for logged in users.
 
 #### `{if comments_expired}`
 


### PR DESCRIPTION
Corrected information about CAPTCHA preferences. There is no CAPTCHA preference for comments on a per channel basis, only as a general preference site-wide.

<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Replace this paragraph with a description of your changes and reasoning. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
<!-- Required when this is associated with an application pull request -->
Application Pull Request: https://github.com/ExpressionEngine/ExpressionEngine/pulls/NNN

<!-- If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine-User-Guide

Thank you for contributing to the ExpressionEngine User Guide! -->
