### PR TITLE
Allow static use of `exp:category_heading`

### DIFF
--- a/docs/channels/category-heading.md
+++ b/docs/channels/category-heading.md
@@ -30,6 +30,20 @@ If no Categories are being shown, the tag will not show anything contained withi
 
 [TOC=3]
 
+### `category_id=`
+
+    category_id="5"
+
+The `category_id=` parameter allows you to override the detection of current category on URL.
+
+### `category_url_title=`
+
+    category_url_title="press-releases"
+
+The `category_url_title=` parameter allows you to override the detection of current category on URL without the use of the [Category URL Titles In Links](control-panel/settings/content-design.md) feature.
+
+NOTE: **Note:** You must specify the `channel` parameter to detect the category title. Unless you are using the `relaxed_categories` parameter, you can only list one channel name, since each channel can have separate category groups.
+
 ### `disable=`
 
     disable="category_fields"


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Allow the `exp:category_heading` to be freely used at any template.

Issue https://github.com/ExpressionEngine/ExpressionEngine/issues/1181

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
<!-- Required when this is associated with an application pull request -->
Application Pull Request: https://github.com/ExpressionEngine/ExpressionEngine/pull/1179

<!-- If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine-User-Guide

Thank you for contributing to the ExpressionEngine User Guide! -->
