### PR TITLE
Add trim variable modifier

### DIFF
--- a/docs/templates/variable-modifiers.md
+++ b/docs/templates/variable-modifiers.md
@@ -200,6 +200,26 @@ Perform a ROT13 substitution cypher to the content.
     {rank:spellout locale='de_DE'}
     {!-- zwei­und­vierzig --}
 
+### `:trim`
+
+Returns a string with whitespace stripped from its beginning and its end.
+
+| Parameter   | Default       |                                                                                              |
+| ----------- | ------------- | -------------------------------------------------------------------------------------------- |
+| characters= | ` \n\r\t\v\0` | As defined by [PHP documentation](https://www.php.net/manual/en/function.trim.php)           |
+
+    {if layout:header_image:trim}
+        <style>
+        .main-header-and-search-form {
+            background-image: url('{layout:header_image:trim}');
+        }
+        </style>
+    {/if}
+
+    {hello:trim characters='Hdle'}
+    {!-- o Wor --}
+
+
 ### `:url`
 
 Normalize a URL to use in markup. Primarily to make sure it contains a valid protocol. For instance if `{website}` was `www.example.com`:


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Add a variable modifier which returns a string with whitespace stripped from its beginning and end as defined at [PHP docs](https://www.php.net/manual/en/function.trim.php).

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#1182](https://github.com/ExpressionEngine/ExpressionEngine/issues/1182).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
<!-- Required when this is associated with an application pull request -->
Application Pull Request: https://github.com/ExpressionEngine/ExpressionEngine/pull/1183

