### PR TITLE
Fix some code typos (missing ','s) in addon-installer.md

### DIFF
--- a/docs/development/addon-installer.md
+++ b/docs/development/addon-installer.md
@@ -62,8 +62,8 @@ Additional functionality can be installed using the following guidelines:
         public $methods = [
             [
                 'method' => 'run', // will default to same as hook if not defined
-                'hook' => 'template_fetch_template' // required
-                'priority' => ""
+                'hook' => 'template_fetch_template', // required
+                'priority' => "",
                 'enabled' => "" // y/n
             ],
             [
@@ -113,8 +113,8 @@ Extension files can now be as simplified as well. However they must include the 
         public $methods = [
             [
                 'method' => 'run', // will default to same as hook if not defined
-                'hook' => 'template_fetch_template' // required
-                'priority' => ""
+                'hook' => 'template_fetch_template', // required
+                'priority' => "",
                 'enabled' => "" // y/n
             ],
             [
@@ -147,8 +147,8 @@ Additionally you may use `activate_extension()` and `disable_extension()` if nee
         public $methods = [
             [
                 'method' => 'run', // will default to same as hook if not defined
-                'hook' => 'template_fetch_template' // required
-                'priority' => ""
+                'hook' => 'template_fetch_template', // required
+                'priority' => "",
                 'enabled' => "" // y/n
             ],
             [


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Code samples on page [Addon Installer](https://docs.expressionengine.com/latest/development/addon-installer.html) have some missing ','s that would lead to errors if examples cut / pasted into live code.  This edit fixes this issue.

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code
