### PR TITLE
Add extra parameters ot `exp:channel:category_archive`

### DIFF
--- a/docs/channels/category-archive.md
+++ b/docs/channels/category-archive.md
@@ -141,7 +141,6 @@ The "order" parameter sets the display order of the entries. Setting options for
 - orderby="title"
 - orderby="comment"
 - orderby="most_recent_comment"
-- orderby="most_used_categories"
 
 If this parameter is not set, it will default to ordering by the title.
 

--- a/docs/channels/category-archive.md
+++ b/docs/channels/category-archive.md
@@ -141,6 +141,7 @@ The "order" parameter sets the display order of the entries. Setting options for
 - orderby="title"
 - orderby="comment"
 - orderby="most_recent_comment"
+- orderby="most_used_categories"
 
 If this parameter is not set, it will default to ordering by the title.
 
@@ -189,6 +190,12 @@ You may restrict to entries with a particular [status](control-panel/channels.md
 Or exclude statuses using "not"
 
     status="not submitted|processing|closed"
+
+### `sticky=`
+
+    sticky="no" sticky="yes" sticky="only"
+
+By default, sticky property makes no difference on entries sorting ("no"). You can manually turn on stickies by setting the parameter to "yes". If set to "only", only "sticky" entries are included in the results.
 
 ### `style=`
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Add `sticky` parameter and `most_used_categories` value to `orderby` parameter to `exp:channel:category_archive`.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
<!-- Required when this is associated with an application pull request -->
Application Pull Request: https://github.com/ExpressionEngine/ExpressionEngine/pull/1257
