### PR TITLE
Allow assign previously created field groups to importing channel sets

### DIFF
--- a/docs/channels/sets.md
+++ b/docs/channels/sets.md
@@ -34,7 +34,7 @@ Channel Sets are zip files containing the following files:
 
 ### Custom Fields
 
-Custom fields are all represented as JSON objects. Each custom field exports its own properties, but `label`, `instructions`, and `order` are always inclued. If after exporting you realize you want to order your fields differently, simply set the `order` property in the order you want the field to appear in:
+Custom fields are all represented as JSON objects. Each custom field exports its own properties, but `label`, `instructions`, and `order` are always included. If after exporting you realize you want to order your fields differently, simply set the `order` property in the order you want the field to appear in:
 
     {
         "label": "Content",
@@ -71,6 +71,8 @@ Your `channel_set.json` file ties everything together. It will contain structura
     }
 
 The array of channels will contain objects that represent each Channel. Each Channel has a `channel_title`, `status_group`, `field_group`, and `cat_groups`, though they can be empty. In addition, you can supply `title_field_label` to change the Title Label on the publish page.
+
+NOTE: **Note:** Field groups mentioned on `channel_set.json`, but not present on `/custom_fields` folder will be assigned to the channel, but not created. Make it sure they are created previously in this case.
 
 #### `statuses`
 


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Allow assignment of previously created field groups to importing channel sets.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#1288](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/issues/1288).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
<!-- Required when this is associated with an application pull request -->
Application Pull Request: https://github.com/ExpressionEngine/ExpressionEngine/pull/1340

<!-- If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine-User-Guide

Thank you for contributing to the ExpressionEngine User Guide! -->
