### PR TITLE
Add details of `attach` method (resolve issue #249)

### DIFF
--- a/docs/development/legacy/libraries/email.md
+++ b/docs/development/legacy/libraries/email.md
@@ -167,6 +167,20 @@ This is an optional message string which can be used if you send HTML formatted 
 
 NOTE: **Note:** If you are using data from a channel entry and not sending an HTML email, then you should use the `entities_to_ascii()` method (text helper) to convert any HTML entities back into ASCII characters before sending the message to the class.
 
+#### `attach($filename, $disposition = '', $newname = NULL, $mime = '')`
+
+| Parameter     | Type      | Description                                                                                                                                                                    |
+| ------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| \$filename    | `String`  | The full local path to the file to attach                                                                                                                                      |
+| \$disposition | `String`  | Optionally set the HTTP header [Content-Disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) for the attachment (default: `attachment`) |
+| \$newname     | `String`  | Optionally set a different name for the attachment  (default same as $filename)                                                                                                |
+| \$mime        | `String`  | Optionally set the HTTP header [Content-Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) for the attachment                                       |
+| Returns       | `Object`  | Email class objects                                                                                                                                                            |
+
+Adds an attachment to a message:
+
+    ee()->email->attach($filename);
+
 #### `send($auto_clear = TRUE)`
 
 | Parameter    | Type      | Description                                                                            |


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Adds information about the `attach` method in the EE email class.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#249](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/issues/249).

## Nature of This Change

<!-- Check all that apply: -->

- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code