### PR TITLE
htaccess_path example: remove trailing forward slash

### DIFF
--- a/docs/general/system-configuration-overrides.md
+++ b/docs/general/system-configuration-overrides.md
@@ -1490,7 +1490,7 @@ Set the server path used by the [Block/Allow](add-ons/blocklist.md) module to [w
 
 Example Usage:
 
-    $config['htaccess_path'] = '/server/path/to/your/.htaccess/';
+    $config['htaccess_path'] = '/server/path/to/your/.htaccess';
 
 ### `ignore_entry_stats`
 Disable entry stats and analytics being saved during creating/updating of entries when using models. Disabling entry stats can lead to improved performance when using models


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

The [*System Configuration Overrides*](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/blob/1519a2eda5c08f6f9b0e37040c71244aae55f8c6/docs/general/system-configuration-overrides.md) provides an example for specifying the `.htaccess` file.

(i.e. [`$config['htaccess_path']`](https://docs.expressionengine.com/latest/general/system-configuration-overrides.html#htaccess_path)).

The example has a trailing forward slash. (It is a file, not a directory)

#### Current Documentation

```php
$config['htaccess_path'] = '/server/path/to/your/.htaccess/';
```

#### Suggested Changes

```php
$config['htaccess_path'] = '/server/path/to/your/.htaccess';
```

> Note: Removed the trailing forward slash.

## Nature of This Change

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code
