### PR TITLE
Remove duplicate default value for cookie_samesite

### DIFF
--- a/docs/general/system-configuration-overrides.md
+++ b/docs/general/system-configuration-overrides.md
@@ -829,7 +829,7 @@ Declare if your cookie should be restricted to a first-party or same-site contex
 | Value  | Behavior                                                                     |
 | ------ | ---------------------------------------------------------------------------- |
 | None   | Allow cookies to be sent on all requests (cookie_secure will be set to true) |
-| Lax    | Allows cookies to be sent on some cross-site requests (default)              |
+| Lax    | Allows cookies to be sent on some cross-site requests                        |
 | Strict | Does not allow cookies to be sent on some cross-site requests (default)      |
 
 Example Usage:


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Currently, the `cookie_samesite` system configuration override documentation show 2 options as being the default.

You can view this here: <https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/blob/1519a2eda5c08f6f9b0e37040c71244aae55f8c6/docs/general/system-configuration-overrides.md#cookie_samesite>

###  ***This pull request changes 'Strict' to be shown as the default... I do not know if this is correct. Please review!***

#### Current `cookie_samesite` table

| Value  | Behavior                                                                     |
| ------ | ---------------------------------------------------------------------------- |
| None   | Allow cookies to be sent on all requests (cookie_secure will be set to true) |
| Lax    | Allows cookies to be sent on some cross-site requests (default)              |
| Strict | Does not allow cookies to be sent on some cross-site requests (default)      |

> Note: `Lax` and `Strict` are shown as being the *default*

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code
