### PR TITLE
Add note to mitigate Issue #321

### DIFF
--- a/docs/development/shared-form-view.md
+++ b/docs/development/shared-form-view.md
@@ -134,7 +134,7 @@ Here are the values available to the `type` key documented above:
 |Field name|Description|
 |--- |--- |
 |text|Regular text input.|
-|short-text|Small text input, typically used when a fieldset needs multiple small, normally numeric, values set.|
+|short-text|Small text input, typically used when a fieldset needs multiple small, normally numeric, values set. <br>N.B. Currently use of this field **requires** the inclusion of an option [label](#individual-field-definitions).|
 |textarea|Textarea input.|
 |select|Select dropdown input.|
 |dropdown|A rich select dropdown .|


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Small addition to text about `short-text` inputs in shared form view documentation to note the current requirement for `label` option to be defined within the field.

<!-- If this pull request resolves a project issue, provide a link: -->
Mitigates [#321](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/issues/321).