### PR TITLE
Update string-helper.md

### DIFF
--- a/docs/development/legacy/helpers/string-helper.md
+++ b/docs/development/legacy/helpers/string-helper.md
@@ -15,7 +15,7 @@ lang: php
 
 The String Helper file contains functions that assist in working with strings. This helper is loaded using the following code:
 
-    $this->load->helper('string');
+    ee()->load->helper('string');
 
 ## Available Functions
 


### PR DESCRIPTION
Update the example of how to load the string helper to begin with `ee()->` rather than `$this->` to be more consistent with other similar examples (e.g. [text helper](https://docs.expressionengine.com/latest/development/legacy/helpers/text-helper.html)).