### PR TITLE
Add `has_children` conditional variable to categories

### DIFF
--- a/docs/channels/categories.md
+++ b/docs/channels/categories.md
@@ -272,6 +272,21 @@ These are totally dynamic in that any field you create for your category will au
 
 You may use this conditional to test whether the category shown is the active category or not, based on the dynamic URI segment.
 
+### `{has_children}`
+
+    {exp:channel:categories channel="news" style="nested" show_empty="no"}
+        <a href="{path='channel/index'}">{category_name}</a>
+
+        {if has_children}
+            <button
+                type="button"
+                aria-haspopup="true"
+            >children categories</button>
+        {/if}
+    {/exp:channel:categories}
+
+You may use this conditional to test whether the category shown is or isn't a parent category.
+
 ## Category Dropdown Menu
 
 You can also display categories in a dropdown menu using the following code:

--- a/docs/channels/category-archive.md
+++ b/docs/channels/category-archive.md
@@ -248,6 +248,20 @@ There are several variables available for use inside the `{categories}{/categori
     {/categories}
 
 You may use this conditional to test whether the category shown is the active category or not, based on the dynamic URI segment.
+### `{has_children}`
+
+    {categories}
+        <a href="{path='channel/index'}">{category_name}</a>
+
+        {if has_children}
+            <button
+                type="button"
+                aria-haspopup="true"
+            >children categories</button>
+        {/if}
+    {/categories}
+
+You may use this conditional to test whether the category shown is or isn't a parent category.
 
 ### `{category_description}`
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Add `{has_children}` variable to `exp:channel:categories` and `exp:channel:category_archive`.

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
<!-- Required when this is associated with an application pull request -->
Application Pull Request: https://github.com/ExpressionEngine/ExpressionEngine/pulls/1727
