### PR TITLE
Fix formatting of options list of CLI

### DIFF
--- a/docs/installation/updating.md
+++ b/docs/installation/updating.md
@@ -52,10 +52,11 @@ To update via the [eecli](cli/intro.md) tool, run:
     php eecli.php update
 
 #### Options
-**rollback**: Rollsback last update
-**verbose,v**: Verbose output
-**force-addon-upgrades**: Automatically runs all addon updaters at end of update (advanced)
-**y**: Skip all confirmations. (advanced)
+
+- **rollback**: Rollsback last update
+- **verbose,v**: Verbose output
+- **force-addon-upgrades**: Automatically runs all addon updaters at end of update (advanced)
+- **y**: Skip all confirmations. (advanced)
 
 ## Updating Manually
 


### PR DESCRIPTION
## Overview

The missing line break turns the following list into one single paragraph.

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code
