### PR TITLE
Add `parse_switch` sample code

### DIFF
--- a/docs/development/legacy/libraries/template.md
+++ b/docs/development/legacy/libraries/template.md
@@ -366,8 +366,11 @@ You may also parse the result rows yourself, which could be useful if for some r
     {
       $row['count'] = ++$count;
       $row['total_results'] = $query->num_rows;
-
-      $output .= ee()->TMPL->parse_variables_row($tagdata, $row);
+      
+      $chunk = ee()->TMPL->parse_variables_row($tagdata, $row);
+      $chunk = ee()->TMPL->parse_switch($chunk, $count - 1);
+      
+      $output .= $chunk;
 
 ## Single and Pair Variables (Legacy)
 


### PR DESCRIPTION
## Overview

I'm not sure the order is right. Should we parse the `{switch=}` always after the other variables?

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

