### PR TITLE
Document `{channel_url}` on `channel:entries`

### DIFF
--- a/docs/channels/entries.md
+++ b/docs/channels/entries.md
@@ -822,6 +822,12 @@ The ID number of the actual channel (not the _entry_.)
 
 The short name of the channel of the currently displayed entry.
 
+### `{channel_url}`
+
+    {channel_url}
+
+The [URL of the channel](control-panel/channels.md#settings-tab) the current entry belongs to, set on Control Panel.
+
 ### `{comment_auto_path}`
 
 This variable is replaced by the URL set in the **Comment Page URL** preference under `Developer --> Channels` in the channel's **Settings** tab. No entry id, URL Title, or other information is included; this is the exact URL from the preference.


### PR DESCRIPTION
## Overview

Add undocumented `{channel_url}` to `exp:channel:entries`.

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code
