### PR TITLE
Allow override of key used for tag caching

### DIFF
--- a/docs/optimization/caching.md
+++ b/docs/optimization/caching.md
@@ -32,6 +32,12 @@ NOTE: **Note:** Refresh indicates the time, in minutes, between cache refreshes.
 For example, to cache your channel tag in 30 minute intervals you'll do this:
 
     {exp:channel:entries cache="yes" refresh="30"}
+    
+The tag caching will be limited to current URL in which the tag are being viewed. If you need use the same data for multiple URLs, set the key used to save the cache:
+
+```html
+    {exp:channel:entries cache="yes" refresh="30" cache_key="recent_entries"}
+```
 
 ## Template Caching
 


### PR DESCRIPTION
## Overview

The use of the [`cache_key` parameter](https://github.com/ExpressionEngine/ExpressionEngine/issues/1185#issuecomment-997117171) would exclude the current URL from the key definition of the cache. Currently, it is the hash of:

- current URL;
- tag content;
- tag parameters.

It would change to:

- tag content;
- tag parameters, including the `cache_key`.

Resolves [#1185](https://github.com/ExpressionEngine/ExpressionEngine/issues/1185).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
<!-- Required when this is associated with an application pull request -->
Application Pull Request: https://github.com/ExpressionEngine/ExpressionEngine/pulls/NNN

<!-- If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine-User-Guide

Thank you for contributing to the ExpressionEngine User Guide! -->
