### PR TITLE
Add details of removeElement() method

### DIFF
--- a/docs/development/services/model/collection.md
+++ b/docs/development/services/model/collection.md
@@ -160,6 +160,24 @@ Iterates over all the elements in the Collection and passes them to them to the 
 | \$callback | `Closure`    | The callback to pass each element to |
 | Returns    | `Collection` | The original collection              |
 
+### `removeElement($model)`
+
+Removes an element from the Collection and returns the reduced Collection.
+
+| Parameter  | Type         | Description                                                   |
+| ---------- | ------------ | ------------------------------------------------------------- |
+| \$model    | `Model`      | An instance of the Model element held in the collection.      |
+| Returns    | `Collection` | The updated collection without the $model element (if found). |
+
+**Note:** This is a handy way to correct for an issue with the EE Model search method which performs `%search_term%` searches rather than literal searches, so you get back all the records that contain the search term in the nominated field rather than those that match the search term. For example, if $collection is a Collection object, this code **removes** any elements that fail to meet a conditional test - so if it had 100 elements to begin with and 5 fail the test, after the code `$collection->count()` will return 95:
+```
+foreach($collection as $element) {
+    if($element->field != 'reference_value') {
+        $collection->removeElement($element);
+    }
+}
+```
+
 ### `count()`
 
 Count the elements in the Collection


### PR DESCRIPTION
I found `removeElement()` while looking for a practical solution to the issue with the EE Model `Search` method - which does bi-directional wildcard searches on the term given rather than literal searches - which in some instances will result in a collection being returned that has too many entries (i.e. you get all those which **contain** the search term in a field rather than **match** the search term).  

Running a foreach() loop on the output testing the 'searched' field against the original search term allows the incorrect elements to be indentified, **removeElement()** allows them to be removed from the collection.

<!-- What's in this pull request? -->
## Overview

**removeElement()** is one of several public methods in the Collection Class that are not documented.

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [X] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code
