### PR TITLE
Add code formatting for TRUE in Input Class Library - Fetching a Superglobal value

### DIFF
--- a/docs/development/legacy/libraries/input.md
+++ b/docs/development/legacy/libraries/input.md
@@ -30,7 +30,7 @@ This class is initialized automatically.
 
 You are not required to use this class to call the incoming data from the superglobal arrays, it will still be available through the superglobals themselves. However, the input class does offer some benefits.
 
-The superglobal methods all allow the specification of an optional second parameter that lets you run the data through the [XSS filter](security). It's enabled by setting the second parameter to boolean TRUE.
+The superglobal methods all allow the specification of an optional second parameter that lets you run the data through the [XSS filter](security). It's enabled by setting the second parameter to `TRUE` (boolean).
 
 Lastly, the superglobal methods will check to see if the item is set and return `FALSE` (boolean) if not. This lets you conveniently use data without having to test whether an item exists first. In other words, normally you might do something like this:
 


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Add formatting for \`TRUE\`.

See the next sentence (line 35), the suggested changes attempt to mimic that.


## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code