### PR TITLE
Get docs correct for all select variants label vs value display

### DIFF
--- a/docs/fieldtypes/checkboxes.md
+++ b/docs/fieldtypes/checkboxes.md
@@ -44,7 +44,7 @@ Checkbox Field values and labels can be displayed in templates using a single va
 You can use a single variable for Checkboxes to render a comma-separated list of the labels.
 
 ```
-{field_name} {!-- 1,2,3 --}
+{field_name} {!-- One,Two,Three --}
 ```
 
 ### Variable Pair
@@ -58,15 +58,15 @@ Using a variable pair, allows for customization of the output.
 The above snippet will render as:
 
 ```
-1
-2
-3
+One
+Two
+Three
 ```
 
-By default, `{item}` will render the item's value. To access the value and label separately, simply add a `:value` or `:label` modifier to the `{item}` variable:
+By default, `{item}` will render the item's label To access the value and label separately, simply add a `:value` or `:label` modifier to the `{item}` variable:
 
     {field_name}
-        Value: {item}<br> {!-- 1 --}
+        Label: {item}<br> {!-- 1 --}
         Value: {item:value}<br> {!-- 1 --}
         Label: {item:label}<br> {!-- One --}
     {/field_name}
@@ -82,18 +82,20 @@ These variables are also available as conditionals. Let's say you had the follow
 
 Given that the selection option is 2/Two:
 
-    {if field_name == 2}Yep!{/if}
+    {if field_name == 'Two'}Yep!{/if}
     {if field_name:value == 2}Yep!{/if}
     {if field_name:label == 'Two'}Yep!{/if}
 
 TIP: **Tip:** It is recommended that you use the value in conditionals, as it typically will not change over time. That way, if you ever need to change the wording, spelling, or even casing of labels in your publish/edit UI, you will not need to modify your templates.
+
+TIP: **Tip:** Checkboxes, Multiselect and Selectable Buttons all default to showing the label. Radio Buttons and Selects default to showing the value. 
 
 ### Limit Parameter
 
 This parameter limits the number of selected items output by the tag. It works for both the single variable, as well as the tag pair.
 
 ```
-{field_name limit="2"} {!-- 1,2 --}
+{field_name limit="2"} {!-- One,Two --}
 ```
 
 ### Markup Parameter

--- a/docs/fieldtypes/multiselect.md
+++ b/docs/fieldtypes/multiselect.md
@@ -44,7 +44,7 @@ Multi Select Field values and labels can be displayed in templates using a singl
 You can use a single variable for Multi Select to render a comma-separated list of the labels.
 
 ```
-{field_name} {!-- 1,2,3 --}
+{field_name} {!-- One,Two,Three --}
 ```
 
 ### Variable Pair
@@ -58,15 +58,15 @@ Using a variable pair, allows for customization of the output.
 The above snippet will render as:
 
 ```
-1
-2
-3
+One
+Two
+Three
 ```
 
-By default, `{item}` will render the item's value. To access the value and label separately, simply add a `:value` or `:label` modifier to the `{item}` variable:
+By default, `{item}` will render the item's label. To access the value and label separately, simply add a `:value` or `:label` modifier to the `{item}` variable:
 
     {field_name}
-        Value: {item}<br> {!-- 1 --}
+        Label: {item}<br> {!-- One --}
         Value: {item:value}<br> {!-- 1 --}
         Label: {item:label}<br> {!-- One --}
     {/field_name}
@@ -82,18 +82,20 @@ These variables are also available as conditionals. Let's say you had the follow
 
 Given that the selection option is 2/Two:
 
-    {if field_name == 2}Yep!{/if}
+    {if field_name == 'Two'}Yep!{/if}
     {if field_name:value == 2}Yep!{/if}
     {if field_name:label == 'Two'}Yep!{/if}
 
 TIP: **Tip:** It is recommended that you use the value in conditionals, as it typically will not change over time. That way, if you ever need to change the wording, spelling, or even casing of labels in your publish/edit UI, you will not need to modify your templates.
+
+TIP: **Tip:** Checkboxes, Multiselect and Selectable Buttons all default to showing the label. Radio Buttons and Selects default to showing the value. 
 
 ### Limit Parameter
 
 This parameter limits the number of selected items output by the tag. It works for both the single variable, as well as the tag pair.
 
 ```
-{field_name limit="2"} {!-- 1,2 --}
+{field_name limit="2"} {!-- One,Two --}
 ```
 
 ### Markup Parameter

--- a/docs/fieldtypes/radio-buttons.md
+++ b/docs/fieldtypes/radio-buttons.md
@@ -65,3 +65,5 @@ Given that the selection option is 2/Two:
     {if field_name:label == 'Two'}Yep!{/if}
 
 TIP: **Tip:** It is recommended that you use the value in conditionals, as it typically will not change over time. That way, if you ever need to change the wording, spelling, or even casing of labels in your publish/edit UI, you will not need to modify your templates.
+
+TIP: **Tip:** Checkboxes, Multiselect and Selectable Buttons all default to showing the label. Radio Buttons and Selects default to showing the value. 

--- a/docs/fieldtypes/select.md
+++ b/docs/fieldtypes/select.md
@@ -69,4 +69,6 @@ Given that the selection option is 2/Two:
 
 TIP: **Tip:** It is recommended that you use the value in conditionals, as it typically will not change over time. That way, if you ever need to change the wording, spelling, or even casing of labels in your publish/edit UI, you will not need to modify your templates.
 
+TIP: **Tip:** Checkboxes, Multiselect and Selectable Buttons all default to showing the label. Radio Buttons and Selects default to showing the value. 
+
 NOTE: **NOTE:** For Select fields used in [Custom Member Fields](control-panel/member-manager.md#custom-member-fields) and [Category Group Details Tab](control-panel/categories.md#details-tab), the modifiers are not currently available in conditionals, and _must_ be based on the value, e.g. `{if some_cat_field == 2}`

--- a/docs/fieldtypes/selectable-buttons.md
+++ b/docs/fieldtypes/selectable-buttons.md
@@ -60,10 +60,10 @@ When allowing multiple items to be selected, Selectable Buttons will usually be 
         {item}<br>
     {/field_name}
 
-By default, `{item}` will render the item's value. To access the value and label separately, simply add a `:value` or `:label` modifier to the `{item}` variable:
+By default, `{item}` will render the item's label. To access the value and label separately, simply add a `:value` or `:label` modifier to the `{item}` variable:
 
     {field_name}
-        Value: {item}<br>
+        Label: {item}<br>
         Value: {item:value}<br>
         Label: {item:label}<br>
     {/field_name}
@@ -74,7 +74,7 @@ TIP: **Tip:** You can use a single variable, e.g. _{field_name}_, and you will g
 
 If "allow multiple selection" setting is turned off, just use the modifier to the single variable name, and do not use a variable pair:
 
-    Value: {field_name}<br>
+    Label: {field_name}<br>
     Value: {field_name:value}<br>
     Label: {field_name:label}<br>
 
@@ -88,11 +88,13 @@ In all cases, these variables are also available as conditionals. Let's say you 
 
 Given that the selection option is 2/Two:
 
-    {if field_name == 2}Yep!{/if}
+    {if field_name == 'Two'}Yep!{/if}
     {if field_name:value == 2}Yep!{/if}
     {if field_name:label == 'Two'}Yep!{/if}
 
 TIP: **Tip:** It is recommended that you use the value in conditionals, as it typically will not change over time. That way, if you ever need to change the wording, spelling, or even casing of labels in your publish/edit UI, you will not need to modify your templates.
+
+TIP: **Tip:** Checkboxes, Multiselect and Selectable Buttons all default to showing the label. Radio Buttons and Selects default to showing the value.
 
 NOTE: **NOTE:** For Select fields used in [Custom Member Fields](control-panel/member-manager.md#custom-member-fields) and [Category Group Details Tab](control-panel/categories.md#details-tab), the modifiers are not currently available in conditionals, and _must_ be based on the value, e.g. `{if some_cat_field == 2}`
 


### PR DESCRIPTION
Selectable Buttons, Checkboxes and Multiselect are displaying the label Radio Buttons and Select are displaying the value.  Can't change the behavior due to backwards compatibility, so making sure docs are clear on the issue.

<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Replace this paragraph with a description of your changes and reasoning. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
<!-- Required when this is associated with an application pull request -->
Application Pull Request: https://github.com/ExpressionEngine/ExpressionEngine/pulls/NNN

<!-- If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine-User-Guide

Thank you for contributing to the ExpressionEngine User Guide! -->
