### PR TITLE
add extra notice on using {if nio_results} in nested tags

### DIFF
--- a/docs/channels/entries.md
+++ b/docs/channels/entries.md
@@ -1224,6 +1224,19 @@ Lastly, if you want to simply display your 404 page (with 404 headers) when no e
 
     {if no_results} {redirect="404"} {/if}
 
+NOTE: **Note:** If you have several nested tag, each one would need to include `{if no_results}` pair to be parsed correctly.
+
+For instance, if you have Grid field with `if no_results` block, the containing `exp:channel:entries` tag pair would need to include `if no_results` block as well.
+```
+{exp:channel:entries channel="blog"}
+    {if no_results} No entries {/if}
+    {my_grid_field}
+        {if no_results} Grid is empty {/if}
+        {my_grid_field:text}
+    {/my_grid_field}
+{/exp:channel:entries}
+```
+
 ### `{if not_category_request}`
 
     {if not_category_request} content {/if}

--- a/docs/channels/entries.md
+++ b/docs/channels/entries.md
@@ -1224,9 +1224,9 @@ Lastly, if you want to simply display your 404 page (with 404 headers) when no e
 
     {if no_results} {redirect="404"} {/if}
 
-NOTE: **Note:** If you have several nested tag, each one would need to include `{if no_results}` pair to be parsed correctly.
+NOTE: **Note:** If you have several nested tags, each one would need to include a `{if no_results}` pair to be parsed correctly.
 
-For instance, if you have Grid field with `if no_results` block, the containing `exp:channel:entries` tag pair would need to include `if no_results` block as well.
+For instance, if you have Grid field with `{if no_results}` block, the parent `{exp:channel:entries}` tag pair would need to include `{if no_results}` block as well.
 ```
 {exp:channel:entries channel="blog"}
     {if no_results} No entries {/if}


### PR DESCRIPTION
@ops-andy this should probably also be included into some generic "tips and tricks" section, as this applies to `{if no_results}` tag anywhere, not just in channel entries - but IDK where is best to put it