### PR TITLE
added note for CP form service.. and removed not on need for PHP 7.1 …

### DIFF
--- a/docs/development/services/cp-form.md
+++ b/docs/development/services/cp-form.md
@@ -13,7 +13,6 @@
 
 The CP/Form Service allows for the creation of Shared Form View data using an object oriented interface. 
 
-TIP: Note this requires PHP >= 7.1
 
 ## Usage
 

--- a/docs/development/shared-form-view.md
+++ b/docs/development/shared-form-view.md
@@ -13,9 +13,13 @@ lang: php
 
 # Shared Form View
 
+TIP: Note. You can also build out control panel views [with objects using the CP form service](development/services/cp-form.md)
+
 [TOC]
 
 ExpressionEngine's control panel markup is very modular and consistent. Because of that, we were able to abstract out the creation of most form views to a single view file to save repeating ourselves and keeping our form markup maintainable. This view is also available to add-on developers and is recommended for built-in support for form validation.
+
+
 
 ## Getting started
 


### PR DESCRIPTION
added note that there is a service for building CP forms... and removed old PHP 7.1 required note as EE 7 is higher then that.