### PR TITLE
Change namespace in sample Atom feed to HTTP

### DIFF
--- a/docs/_downloads/sample-atom.txt
+++ b/docs/_downloads/sample-atom.txt
@@ -4,7 +4,7 @@
 {exp:rss:feed channel="{master_channel_name}"}
 
 <?xml version="1.0" encoding="{encoding}"?>
-<feed xmlns="https://www.w3.org/2005/Atom" xml:lang="{channel_language}">
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{channel_language}">
 
     <title type="text"><![CDATA[{channel_name}]]></title>
     <subtitle type="text"><![CDATA[{channel_name} - {channel_description}]]></subtitle>


### PR DESCRIPTION


<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview
Changes the line `<feed xmlns="https://www.w3.org/2005/Atom" xml:lang="{channel_language}">`
to `<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{channel_language}">` in the sample Atom feed template.

Feed parsers expect the namespace to use HTTP and will not read the feed if the namespace uses HTTPS. E.g. when attempting to test one of my websites' feeds in Miniflux, it gave the error:

> Unable to parse Atom feed: "expected element \<feed\> in name space http://www.w3.org/2005/Atom but have https://www.w3.org/2005/Atom"

https://tt-rss.org/myfeedsucks/ also could not read the feed.

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code
