### PR TITLE
Pro Search docs edits for form tags

### DIFF
--- a/docs/add-ons/pro-search/tags.md
+++ b/docs/add-ons/pro-search/tags.md
@@ -43,11 +43,15 @@ Set to no to have a given query overwrite a valid shortcut. Defaults to yes (a s
 
 #### form_attribute
 
-Specifies any html attribute you want the form to have. For example: form_id="search" will add id="search" to the
+Specifies any html attribute you want the form to have. For example: form_id="search" will add id="search", or form_class="searchform" will add class="searchform" to the tag.
 
-tag. query Use this parameter to pass through a previously executed encoded search query. Not needed when not encoding queries.
+    {exp:pro_search:form form_id="search" form_class="searchform"}
 
-    {exp:pro_search:form form_id="search"}
+#### query
+
+Use this parameter to pass through a previously executed encoded search query. Not needed when not encoding queries.
+
+    {exp:pro_search:form query="{segment_3}"}
 
 #### required
 

--- a/docs/add-ons/pro-search/tags.md
+++ b/docs/add-ons/pro-search/tags.md
@@ -49,7 +49,7 @@ Specifies any html attribute you want the form to have. For example: form_id="se
 
 #### query
 
-Use this parameter to pass through a previously executed encoded search query. Not needed when not encoding queries.
+Use this parameter to pass through a previously executed encoded search query. Not needed when [not encoding queries](https://docs.expressionengine.com/latest/add-ons/pro-search/settings.html#encode-query).
 
     {exp:pro_search:form query="{segment_3}"}
 


### PR DESCRIPTION
Edits made to the Tags descriptions for Pro Search.

Reason - I was searching the Docs to find how to add my own 'class' attribute to {exp:pro_search:form}, but I couldn't find it. Later saw it was described under the 'form_attribute' tag parameter. Thought that by also adding a 'class' example here it would help speed up people's searches for this requirement.

## Nature of This Change
- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ x ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code