### PR TITLE
Add redirect to common functions documentation

### DIFF
--- a/docs/development/legacy/common-functions.md
+++ b/docs/development/legacy/common-functions.md
@@ -153,3 +153,21 @@ This function returns a _reference_ to the MIMEs array from `system/ee/legacy/co
 | Returns   | `Bool` | TRUE if currently using HTTP-over-SSL, FALSE if not |
 
 Returns `TRUE` if a secure (HTTPS) connection is used and `FALSE` in any other case (including non-HTTP requests).
+
+### `redirect($location, [$method = false, [$status_code = null]])`
+
+| Parameter     | Type     | Description                                     |
+| ------------- | -------- | ----------------------------------------------- |
+| \$location    | `String` | Location header holding the URL to redirect to. |
+| \$method      | `String` | Location header holding the URL to redirect to. |
+| \$status_code | `String` | HTTP response status codes.                     |
+| Returns       | `Void`   |                                                 |
+
+When browsers receive a redirect, they immediately load the new URL provided in the Location header.
+
+Example:
+
+    $redirect_url = ee('CP/URL')->make('addons/settings/amazing_add_on')->compile();
+    ee()->functions->redirect($redirect_url);
+
+NOTE: Redirect responses have [status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) that start with `3`.


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Add documentation for the [`redirect()`](https://github.com/ExpressionEngine/ExpressionEngine/blob/61e559413f40324d888ff9ebf4f43dc5f74e8ea1/system/ee/legacy/libraries/Functions.php#L416) method within the common functions documentation.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#706](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/issues/706).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

<!-- If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine-User-Guide

Thank you for contributing to the ExpressionEngine User Guide! -->
