### PR TITLE
Add documentation for `send_ajax_response()` to Output Class library documentation

### DIFF
--- a/docs/development/legacy/libraries/output.md
+++ b/docs/development/legacy/libraries/output.md
@@ -158,3 +158,21 @@ Example:
     exit;
 
 NOTE: **Note:** Calling this method manually without aborting script execution will result in duplicated output.
+
+### `send_ajax_response($msg, [$error = false])`
+
+| Parameter | Type     | Description          |
+| --------- | -------- | -------------------- |
+| \$msg  | `Array` | Object to be sent to the client. |
+| \$error  | `Bool` | TRUE to set header status to `500` |
+| Returns   | `Void`   | void                 |
+
+Calling this method encode the given `$msg` parameter and will set the header `Content-Type: application/json`.
+
+Example:
+
+    $output = array(
+        'this' => 'that',
+        'foo' => 'bar'
+    );
+    ee()->output->send_ajax_response($output);


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Add documentation for the [`send_ajax_response()`](https://github.com/ExpressionEngine/ExpressionEngine/blob/61e559413f40324d888ff9ebf4f43dc5f74e8ea1/system/ee/legacy/core/Output.php#L669-L693) method in the Output Class library documentation.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#708](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/issues/708).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

<!-- If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine-User-Guide

Thank you for contributing to the ExpressionEngine User Guide! -->
