### PR TITLE
Tab Development - semicolon missing in sample code

### DIFF
--- a/docs/development/tab-files.md
+++ b/docs/development/tab-files.md
@@ -52,7 +52,7 @@ class Amazing_add_on_tab
 
         $settings = [
             //array of settings
-        ]
+        ];
         return $settings;
     }
 


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

I copied and pasted this code into my editor - noticed that a semicolon was missing. 

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [x] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code
