### PR TITLE
Add-on Update File - return values from parent installer class

### DIFF
--- a/docs/development/add-on-update-file.md
+++ b/docs/development/add-on-update-file.md
@@ -37,24 +37,18 @@ class Amazing_add_on_upd extends Installer
 
     public function install()
     {
-        parent::install();
-
-        return true;
+        return parent::install();
     }
 
     public function update($current = '')
     {
         // Runs migrations
-        parent::update($current);
-
-        return true;
+        return parent::update($current);
     }
 
     public function uninstall()
     {
-        parent::uninstall();
-
-        return true;
+        return parent::uninstall();
     }
 }
 ```
@@ -79,13 +73,11 @@ The CLI automatically generates our install method. This method will ensure that
 ```
    public function install()
     {
-        parent::install();
-
         // create a database table
         // notify mission control
         // add publish tabs
 
-        return true;
+        return parent::install();
     }
 ```
 
@@ -140,9 +132,6 @@ The `update` method will run code when a user installs an update to our add-on.
 
     public function update($current = '')
     {
-        // Runs migrations
-        parent::update($current);
-
         // only run the update if the user is currently running a version less than 2.0
         if (version_compare($current, '2.0', '<'))
         {
@@ -150,9 +139,9 @@ The `update` method will run code when a user installs an update to our add-on.
             // update database
             // notify mission control of the update
         }
-        
 
-        return true;
+        // Runs migrations
+        return parent::update($current);
     }
 
 ## Uninstall Your Add-On (`uninstall()`)
@@ -164,13 +153,11 @@ The CLI automatically generates our uninstall method. This method will ensure th
 
     public function uninstall()
     {
-        parent::uninstall();
-
         // remove my database tables
         // remove any publish tabs
         // turn off the lights
 
-        return true;
+        return parent::uninstall();;
     }
 
 ### Removing Tabs


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

In previous versions of the documentation, the value returned from `install()/uninstall()` is determined by the invocation of the parent class methods. See [here](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/blob/3765a177c38fbc82986a68b32d4ceb2fe2589dd2/docs/development/addon-installer.md#module-installer).

### Supporting Argument

Lets examine the routine which a add-on may encounter during installation (`install()`). All add-ons (which poses modules) must update the `exp_modules` database table. This process is taken care of by calling `parent::install()`. Then lets suppose that the add on needs to create a database table. 

Steps

- update `exp_modules` table
- create add-on dependent database forge operations

If the order of these operation takes place such that the module is added and then the database tables are created, an error may occur in which the add-on is not successfully installed. 

Current order of operations (see Sample Code below)

1. update `exp_modules` table
2. create add-on dependent database forge operations

Lets say for example that there is an issue when creating the database tables. The problem here is that the modules database table (`exp_modules`) has been updated to suggest that the add-on is in fact installed correctly. But during installation, the error occurred in which necessary database forge operations did not successfully complete.

Suggested order of operations


1. create add-on dependent database forge operations
2. update `exp_modules` table

This would allow the add-on to independently validate whether or not the installation process completed successfully before the parent operations took place.

### Code Samples

**Current Documentation**

```
    public function install()
    {
        parent::install();

        // create a database table
        // notify mission control
        // add publish tabs

        return true;
    }
```

**Old Documentaion**

```
    public function install()
    {
        
        // create a database table
        // notify mission control
        // add publish tabs

        return parent::install();;
    }
```

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code
