### PR TITLE
Fix closing tag syntax - Forgot Username Form Tag

### DIFF
--- a/docs/member/forgot-username.md
+++ b/docs/member/forgot-username.md
@@ -22,7 +22,7 @@ Output a forgotten username form that sends an email with instructions for addre
 
 			<input type="submit" name="submit" value="Submit" />
 
-    {/{exp:member:forgot_username_form}
+    {/exp:member:forgot_username_form}
 
 ## Parameters
 


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Fix closing tag for `{exp:member:forgot_username_form}` example. See commit changes.

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [x] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code
