### PR TITLE
Add pipeDelimited to Model Service Typed Columns

### DIFF
--- a/docs/development/services/model/building-your-own.md
+++ b/docs/development/services/model/building-your-own.md
@@ -262,6 +262,7 @@ The available options include:
 | boolString | Cast to y/n       | Cast to boolean  |
 | yesNo      | Cast to y/n       | Cast to boolean  |
 | timestamp  | Cast to timestamp | Cast to DateTime |
+| pipeDelimited | Cast to string | Cast to array    |
 
 ## Composite Types
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Adds documentation for the Model Service. Specifically, this PR adds `pipeDelimited` to the [typed columns](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/blob/efdeff05a0c3eee63d0a8abebe25bc3798f5c9a4/docs/development/services/model/building-your-own.md#building-your-own-models#typed-columns) section under [Building your own Models](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/blob/efdeff05a0c3eee63d0a8abebe25bc3798f5c9a4/docs/development/services/model/building-your-own.md#building-your-own-models#building-your-own-models).

I was browsing the [UploadDestination](https://github.com/ExpressionEngine/ExpressionEngine/blob/22268166c22cfe79fd634a5c094600703ec49235/system/ee/ExpressionEngine/Model/File/UploadDestination.php#L71) model class file and noticed that the [`_type_columns`](https://github.com/ExpressionEngine/ExpressionEngine/blob/22268166c22cfe79fd634a5c094600703ec49235/system/ee/ExpressionEngine/Model/File/UploadDestination.php#L69-L75) array included a value pair I was not aware of. So, I am suggesting that we include this functionality in the documentation!

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [x] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

