### PR TITLE
Update Human-readable time for legacy Localize Class (missing $include_time parameter)

### DIFF
--- a/docs/development/legacy/libraries/localization.md
+++ b/docs/development/legacy/libraries/localization.md
@@ -74,13 +74,14 @@ Similar to PHP's `strtotime()`, the Localize class provides a way to take a pre-
 
 ## Human-readable time
 
-### `human_time([$timestamp = NULL[, $localize = TRUE[, $seconds = FALSE]]])`
+### `human_time([$timestamp = NULL[, $localize = TRUE[, $seconds = FALSE[, $include_time = TRUE]]]])`
 
 | Parameter   | Type      | Description                                                                                                                                                   |
 | ----------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | \$timestamp | `Integer` | Unix timestamp                                                                                                                                                |
 | \$localize  | `Boolean` | Boolean of whether to use the current member's timezone for localization (TRUE), or to use GMT (FALSE); or string of PHP timezone to use for the localization |
 | \$seconds   | `Boolean` | Whether or not to include seconds, overrides `include_seconds` hidden config                                                                                  |
+| \$include_time | `Boolean` | Whether or not to include time                                                                                                                             |
 | Returns     | `String`  | Human-readable date                                                                                                                                           |
 
 Returns a common human-readable date format conforming to ExpressionEngine's [default time formatting setting](control-panel/settings/general.md). This method is most commonly used to express dates in the control panel.

--- a/docs/development/legacy/libraries/localization.md
+++ b/docs/development/legacy/libraries/localization.md
@@ -76,13 +76,13 @@ Similar to PHP's `strtotime()`, the Localize class provides a way to take a pre-
 
 ### `human_time([$timestamp = NULL[, $localize = TRUE[, $seconds = FALSE[, $include_time = TRUE]]]])`
 
-| Parameter   | Type      | Description                                                                                                                                                   |
-| ----------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| \$timestamp | `Integer` | Unix timestamp                                                                                                                                                |
-| \$localize  | `Boolean` | Boolean of whether to use the current member's timezone for localization (TRUE), or to use GMT (FALSE); or string of PHP timezone to use for the localization |
-| \$seconds   | `Boolean` | Whether or not to include seconds, overrides `include_seconds` hidden config                                                                                  |
-| \$include_time | `Boolean` | Whether or not to include time                                                                                                                             |
-| Returns     | `String`  | Human-readable date                                                                                                                                           |
+| Parameter      | Type      | Description                                                                                                                                                   |
+| -------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| \$timestamp    | `Integer` | Unix timestamp                                                                                                                                                |
+| \$localize     | `Boolean` | Boolean of whether to use the current member's timezone for localization (TRUE), or to use GMT (FALSE); or string of PHP timezone to use for the localization |
+| \$seconds      | `Boolean` | Whether or not to include seconds, overrides `include_seconds` hidden config                                                                                  |
+| \$include_time | `Boolean` | Whether or not to include time                                                                                                                                |
+| Returns        | `String`  | Human-readable date                                                                                                                                           |
 
 Returns a common human-readable date format conforming to ExpressionEngine's [default time formatting setting](control-panel/settings/general.md). This method is most commonly used to express dates in the control panel.
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Updates the documentation for `ee()->localize->human_time()`. The existing docs are missing information about the `$include_time` parameter.

**See source code for reference**: [Localize::human_time()](https://github.com/ExpressionEngine/ExpressionEngine/blob/ccbbf02bf9059a17cea5d994ac688022c94ced48/system/ee/legacy/libraries/Localize.php#L196-L207)

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code
