### PR TITLE
Added undocumented parameters for :json variable modifier

### DIFF
--- a/docs/templates/variable-modifiers.md
+++ b/docs/templates/variable-modifiers.md
@@ -113,6 +113,11 @@ Make the content safe to use as the value of a form field.
 
 ### `:json`
 
+| Parameter            | Default   |                                                                                                                             |
+| -------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------- |
+| double_encode=       | `no`      | Whether or not to double encode already-encoded entities, e.g. should `&quot;` become `&amp;quot;`?                         |                           |
+| enclose_with_quotes= | `yes`     | Whether the output is automatically enclosed in quotes |
+
 Encode the content for JSON output.
 
     "headline": {title:json},

--- a/docs/templates/variable-modifiers.md
+++ b/docs/templates/variable-modifiers.md
@@ -115,7 +115,7 @@ Make the content safe to use as the value of a form field.
 
 | Parameter            | Default   |                                                                                                                             |
 | -------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------- |
-| double_encode=       | `no`      | Whether or not to double encode already-encoded entities, e.g. should `&quot;` become `&amp;quot;`?                         |                           |
+| double_encode=       | `yes`      | Whether or not to double encode already-encoded entities, e.g. should `&quot;` become `&amp;quot;`?                         |                           |
 | enclose_with_quotes= | `yes`     | Whether the output is automatically enclosed in quotes |
 
 Encode the content for JSON output.


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

The :json variable modifier accepts two parameters according to the code (ee/ExpressionEngine/Service/Formatter/Formats/Text.php) that are currently undocumented. 

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [X ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
<!-- Required when this is associated with an application pull request -->
Application Pull Request: https://github.com/ExpressionEngine/ExpressionEngine/pulls/NNN

<!-- If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine-User-Guide

Thank you for contributing to the ExpressionEngine User Guide! -->
