### PR TITLE
Add {site_id} to single-variables.md

### DIFF
--- a/docs/templates/globals/single-variables.md
+++ b/docs/templates/globals/single-variables.md
@@ -183,6 +183,10 @@ This variable will be substituted with your site name as defined under `Settings
 
 This variable will be substituted with your site URL as defined under `Settings --> URL and Path Settings`.
 
+### `{site_id}`
+
+This variable will be substituted with the ID of your site as defined under `Developer --> Sites` (if MSM is enabled).
+
 ### `{template_name}`
 
 This variable displays the name of the template currently being processed.:


### PR DESCRIPTION
Adds existing {site_id} global variable to the corresponding doc page.

<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Adds {site_id} (an existing but undocumented single variable) to the global single variables doc page.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [X] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
<!-- Required when this is associated with an application pull request -->
Application Pull Request: https://github.com/ExpressionEngine/ExpressionEngine/pulls/NNN

<!-- If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine-User-Guide

Thank you for contributing to the ExpressionEngine User Guide! -->
