### PR TITLE
Added CLI error troubleshooting

### DIFF
--- a/docs/troubleshooting/error-messages.md
+++ b/docs/troubleshooting/error-messages.md
@@ -109,6 +109,29 @@ This error happens when ExpressionEngine tries to save content with an emoji to 
 
 This happens when the query has a syntax error.  However, if you can't see an obvious syntax error and the query runs in other environments, it may be a server configuration issue.  Make certain MySQL is not running with  [ANSI_QUOTES](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_ansi_quotes) on.
 
+## PHP Fatal error:  Uncaught PDOException: SQLSTATE[HY000] [2002]
+
+This may happen when attempting to use the CLI when the ExpressionEngine intallation is running on [MAMP](https://www.mamp.info/).
+
+### Troubleshooting
+
+Change the following configuration values in config.php: hostname, port.  See example:
+
+```php
+$config['database'] = array(
+	'expressionengine' => array(
+		'hostname' => '127.0.0.1',
+		'database' => 'EEdb',
+		'username' => 'root',
+		'password' => 'root',
+		'dbprefix' => 'exp_',
+		'char_set' => 'utf8mb4',
+		'dbcollat' => 'utf8mb4_unicode_ci',
+		'port'     => '8889'
+	)
+);
+```
+
 ## Missing Encryption Keys
 
 ExpressionEngine displays the error: **You do not have value set for \[encryption_key/session_crypt_key\] in your config.php. This may leave your install open to security vulnerabilities. Restore the keys or see this troubleshooting article in the user guide for help.**

--- a/docs/troubleshooting/error-messages.md
+++ b/docs/troubleshooting/error-messages.md
@@ -115,7 +115,7 @@ This may happen when attempting to use the CLI when the ExpressionEngine intalla
 
 ### Troubleshooting
 
-Change the following configuration values in config.php: hostname, port.  See example:
+Check following configuration values in config.php: hostname, port.  Hostname may need to be ```127.0.0.1``` instead of ``localhost`` and the port may differ from the default 3306.  You can check the port used in the MAMP MySQL settings.  For example:
 
 ```php
 $config['database'] = array(


### PR DESCRIPTION
PHP Fatal error:  Uncaught PDOException: SQLSTATE[HY000] [2002] No such file or directory in /home/runner/work/ExpressionEngine-Private/ExpressionEngine-Private/system/ee/legacy/database/drivers/mysqli/mysqli_connection.php:78 error on MAMP installs