### PR TITLE
Added info on tag copying

### DIFF
--- a/docs/control-panel/channels.md
+++ b/docs/control-panel/channels.md
@@ -11,9 +11,12 @@
 
 **Control Panel Location: `Developer > Channels`**
 
-This section of the Control Panel is where channels are created, edited and deleted. 
+This section of the Control Panel is where channels are created, edited and deleted.
 
-The channel shortname on the main display supports quick copying the full template tag for the channel, including all fields assigned to the channel. The copied code is ready to use on your [templates](templates/overview.md). Quick copying code via the channel shortname is only supported when on HTTPS.
+The channel shortname on the main display supports quick copying the full template tag for the channel, including all fields assigned to the channel. The copied code is ready to use on your [templates](templates/overview.md).  Displaying the short name can be toggled on or off in the [Role](control-panel/member-manager.md) settings.
+
+NOTE:
+Due to security restrictions in modern browsers quick copying code via the shortname is only supported when on HTTPS.
 
 [TOC]
 

--- a/docs/control-panel/channels.md
+++ b/docs/control-panel/channels.md
@@ -11,7 +11,9 @@
 
 **Control Panel Location: `Developer > Channels`**
 
-This section of the Control Panel is where channels are created, edited and deleted.
+This section of the Control Panel is where channels are created, edited and deleted. 
+
+The channel shortname on the main display supports quick copying the full template tag for the channel, including all fields assigned to the channel. The copied code is ready to use on your [templates](templates/overview.md). Quick copying code via the channel shortname is only supported when on HTTPS.
 
 [TOC]
 

--- a/docs/control-panel/create.md
+++ b/docs/control-panel/create.md
@@ -39,7 +39,7 @@ NOTE: **Note:** If you let the system create your URL Title for you it will conv
 
 ### Entry Fields
 
-The names and types of entry custom fields displayed will be determined by what [Fields](/fieldtypes/overview.md) you have defined for this channel. 
+The names and types of entry custom fields displayed will be determined by what [Fields](/fieldtypes/overview.md) you have defined for this channel.
 
 If an entry field is set to be "hidden" by default, it will have to be expanded by clicking on the field name before content can be entered.
 
@@ -51,7 +51,10 @@ This can be done in two ways:
 - assign custom field to a [Field Group](/control-panel/field-manager/field-manager-settings.md#createedit-field-group) which is associated to the Channel
 - assign field directly to channel by editing [Channel preferences](control-panel/channels.md#fields-tab)
 
-When working with [templates](templates/overview.md) you will be referencing the field by its short name or tag pair. For convenience the short name can be displayed next to the field's name in the publish form (<img style="margin-bottom: 0px; vertical-align: middle; display:inline-block;" src="../_images/field_short_name.png" alt="field short name">) and the variable(s) required to display the content will be copied to the clipboard when clicked. Displaying the short name can be toggled on or off in the [Role](control-panel/member-manager.md) settings.  Copying code via the shortname is only supported when on HTTPS.
+When working with [templates](templates/overview.md) you will be referencing the field by its short name or tag pair. For convenience the short name can be displayed next to the field's name in the publish form (<img style="margin-bottom: 0px; vertical-align: middle; display:inline-block;" src="../_images/field_short_name.png" alt="field short name">) and the variable(s) required to display the content will be copied to the clipboard when clicked. Displaying the short name can be toggled on or off in the [Role](control-panel/member-manager.md) settings.
+
+NOTE:
+Due to security restrictions in modern browsers quick copying code via the shortname is only supported when on HTTPS.
 
 Note that some fields can be displayed with just single tags while others would require a tag pair with extra variables. More information can be found in the documentation for the field's specific [field type](fieldtypes/overview.md).
 
@@ -189,6 +192,6 @@ A live preview of the entry is available if the `channel_prefs_preview_url` is s
 
 If neither is set, the preview button will have an exclamation mark (!) and will link to channel preferences page where Preview URL can be set.
 
-The preview will open a split screen that allows a live preview of edits. The template used to display the preview is based on the Page fields if set and the channel preview URL otherwise. 
+The preview will open a split screen that allows a live preview of edits. The template used to display the preview is based on the Page fields if set and the channel preview URL otherwise.
 
 When the preview is triggered, it is being displayed side-by-side with edit screen. The size of preview container can be adjusted with mouse dragging its border. The preview is dynamically being updated as you change the fields.

--- a/docs/control-panel/create.md
+++ b/docs/control-panel/create.md
@@ -51,7 +51,7 @@ This can be done in two ways:
 - assign custom field to a [Field Group](/control-panel/field-manager/field-manager-settings.md#createedit-field-group) which is associated to the Channel
 - assign field directly to channel by editing [Channel preferences](control-panel/channels.md#fields-tab)
 
-When working with [templates](templates/overview.md) you will be referencing the field by its short name. For convenience the short name can be displayed next to the field's name in the publish form (<img style="margin-bottom: 0px; vertical-align: middle; display:inline-block;" src="../_images/field_short_name.png" alt="field short name">) and will be copied to the clipboard when clicked. Displaying the short name can be toggled on or off in the [Role](control-panel/member-manager.md) settings.
+When working with [templates](templates/overview.md) you will be referencing the field by its short name or tag pair. For convenience the short name can be displayed next to the field's name in the publish form (<img style="margin-bottom: 0px; vertical-align: middle; display:inline-block;" src="../_images/field_short_name.png" alt="field short name">) and the variable(s) required to display the content will be copied to the clipboard when clicked. Displaying the short name can be toggled on or off in the [Role](control-panel/member-manager.md) settings.  Copying code via the shortname is only supported when on HTTPS.
 
 Note that some fields can be displayed with just single tags while others would require a tag pair with extra variables. More information can be found in the documentation for the field's specific [field type](fieldtypes/overview.md).
 

--- a/docs/control-panel/field-manager/field-manager-settings.md
+++ b/docs/control-panel/field-manager/field-manager-settings.md
@@ -17,6 +17,8 @@ This section of the Control Panel is where custom fields are created, edited and
 
 ![](_images/cp-field-manager.png)
 
+The field shortname supports quick copying the full tag needed to display the field. The copied can is ready to use on your [templates](templates/overview.md).  Quick copying code via the channel shortname is only supported when on HTTPS.
+
 Tip: How to Find Where a Field Is Used
 <div class="video-wrapper">
 <iframe src="https://www.youtube.com/embed/vXbm9aoOQXU?si=VoUJjU-9gvsNKHT7" title="How to Determine Where Channel Fields are Used in ExpressionEngine" width="1920" height="1080" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>

--- a/docs/control-panel/field-manager/field-manager-settings.md
+++ b/docs/control-panel/field-manager/field-manager-settings.md
@@ -17,7 +17,7 @@ This section of the Control Panel is where custom fields are created, edited and
 
 ![](_images/cp-field-manager.png)
 
-The field shortname supports quick copying the full tag needed to display the field. The copied can is ready to use on your [templates](templates/overview.md).  Quick copying code via the channel shortname is only supported when on HTTPS.
+The field shortname supports quick copying the full tag needed to display the field. The copied can is ready to use on your [templates](templates/overview.md).  Displaying the short name can be toggled on or off in the [Role](control-panel/member-manager.md) settings.  Due to security restrictions in modern browsers quick copying code via the shortname is only supported when on HTTPS.
 
 Tip: How to Find Where a Field Is Used
 <div class="video-wrapper">

--- a/docs/control-panel/member-manager.md
+++ b/docs/control-panel/member-manager.md
@@ -82,13 +82,13 @@ This tab contains the generic settings for the role. You can also assign the rol
 
 - **Include members in: author/member lists.**
 -- Roles included in the author list are available in the author select field on the entry publish/edit page for any channel the role has permission to publish in.
--- Roles included in the member lists are available to display in the [member list tag](member/memberlist.md).  
+-- Roles included in the member lists are available to display in the [member list tag](member/memberlist.md).
 
 - **Security Lock** -- If enabled, only Super Admin users can add or remove members to the role.
 
 - **Role Groups** -- Assign the role to [role groups](control-panel/member-manager.md#role-groups).
 
-- **Show field names on Publish** -- Enables the display of the field tags on the entry publish/edit page. This option is only available to the Super Admin role.
+- **Show field names on Publish** -- Enables the display of field short names on the entry publish/edit page.
 
 Tip: Hide and Show Field Short Names in the Publish Area
 <div class="video-wrapper">


### PR DESCRIPTION
updated entry create and added info to channel and field manager pages on copying tags.  Included https requirement.

<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Replace this paragraph with a description of your changes and reasoning. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
<!-- Required when this is associated with an application pull request -->
Application Pull Request: https://github.com/ExpressionEngine/ExpressionEngine/pulls/NNN

<!-- If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine-User-Guide

Thank you for contributing to the ExpressionEngine User Guide! -->
