### PR TITLE
Add strip image metadata setting

### DIFF
--- a/docs/control-panel/settings/security-privacy.md
+++ b/docs/control-panel/settings/security-privacy.md
@@ -152,6 +152,10 @@ Similar to the previous setting, when turned on, this setting requires IP addres
 
 Checks all file uploads for code injection attempts before finalizing the upload. Superadmins are exempt from image XSS filtering.
 
+### Strip Image Metadata?
+
+This setting will remove all metadata from an image during upload, including GPS data. This requires the Imagick PHP extension.
+
 ### Enable Rank Denial to submitted links?
 
 When enabled, all outgoing links are sent to a redirect page. This prevents spammers from [gaining page rank](https://support.google.com/webmasters/answer/96569?hl=en).


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Adds the strip image metadata setting. 

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
<!-- Required when this is associated with an application pull request -->
Application Pull Request: https://github.com/ExpressionEngine/ExpressionEngine/pull/4555

