### PR TITLE
Add advanced example to automatically open a modal

### DIFF
--- a/docs/development/services/modal.md
+++ b/docs/development/services/modal.md
@@ -130,6 +130,18 @@ Finally, we need to create our Bulk Action Controls with some special data attri
 
 Now when a user selects some content in the table, the bulk action controls should appear, and when "Remove" is selected and submitted, a modal will appear showing a list of content about to be deleted, where they can then confirm the deletion and your `POST` handler will be fired.
 
+## Advanced functionality
+
+### Automatically open a modal
+
+If you manually build a modal view, you can add `.app-modal` and a `rev` attribute like:
+
+    <div class="modal-wrap app-modal" rev="my-automatic-modal">
+
+Then, visiting the CP page with `#my-automatic-modal` in the URL will automatically open this modal on page load.
+
+NOTE: Note: the `rev` value must be longer than 5 characters in order for this to work. `#test` would not work, but `#testing` would.
+
 ## CP/Modal Service Methods
 
 **class `ExpressionEngine\Service\Modal\ModalCollection`**


### PR DESCRIPTION
## Overview

Added documentation for how to automatically open a modal on page load.

<img width="1204" alt="image" src="https://github.com/user-attachments/assets/2e7a47f3-3784-41b3-83c1-9c5dfec09d7b" />


## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
Not applicable - this is existing functionality as seen at https://github.com/ExpressionEngine/ExpressionEngine/blob/7.dev/themes/ee/asset/javascript/src/common.js#L765-L770
