### PR TITLE
Replace <group_id> with <role_id> in XML format

### DIFF
--- a/docs/general/member-import-xml-format.md
+++ b/docs/general/member-import-xml-format.md
@@ -92,7 +92,7 @@ NOTE: **Note:** If you import encrypted passwords of one type and your Expressio
 - `<display_signatures>`
 - `<email>`
 - `<forum_theme>`
-- `<group_id>`
+- `<role_id>`
 - `<in_authorlist>`
 - `<ip_address>`
 - `<join_date>`


### PR DESCRIPTION
Updates a mistake - referencing an old parameter name.
