### PR TITLE
The behavior of strict_urls in the case of page indicators was unclear

### DIFF
--- a/docs/control-panel/settings/template.md
+++ b/docs/control-panel/settings/template.md
@@ -25,6 +25,8 @@ If you wish to extend this to the second segment, requiring a valid template, th
 
 Our official recommendation is that users **enable** Strict URLs, as doing so makes the path to your content more precise, allows more relevant 404 pages, and does not allow your content to be shown with variances in the URL structure. However, for legacy reasons, Strict URLs are disabled by default.
 
+NOTE: **Note:** The pagination indicator Px is considered a valid first segment and will not trigger a 404 in order to allow pagination on the index page. Thus https://example.com/P5 will not trigger a 404 withe strict_urls enabled.
+
 ### 404 page
 
 This determines which template should be displayed when someone tries to access an invalid URL. If you choose "None", a standard 404 message and server header will be shown.

--- a/docs/general/system-configuration-overrides.md
+++ b/docs/general/system-configuration-overrides.md
@@ -2987,6 +2987,8 @@ Example Usage:
 
     $config['strict_urls'] = 'n';
 
+NOTE: **Note:** The pagination indicator Px is considered a valid first segment and will not trigger a 404 in order to allow pagination on the index page. Thus https://example.com/P5 will not trigger a 404 withe strict_urls enabled.
+
 **Also found in CP:** `Settings --> Template Settings`: [Enable Strict URLs](control-panel/settings/template.md#enable-strict-urls)
 
 ## `template`


### PR DESCRIPTION
Came up in support as confusing and I'd agree.
