### PR TITLE
Update system-configuration-overrides.md

### DIFF
--- a/docs/general/system-configuration-overrides.md
+++ b/docs/general/system-configuration-overrides.md
@@ -1283,7 +1283,7 @@ Example Usage:
 
     $config['enable_frontedit'] = 'n';
 
-## `enable_frontedit_links`
+## `automatic_frontedit_links`
 
 When set to `n`, disables automatic creation of content management links on front-end. The links can still be [added manually](advanced-usage/front-end/frontend.md#customizing-the-link-location).
 
@@ -1294,7 +1294,7 @@ When set to `n`, disables automatic creation of content management links on fron
 
 Example Usage:
 
-    $config['enable_frontedit_links'] = 'y';
+    $config['automatic_frontedit_links'] = 'y';
 
 ## `enable_hit_tracking`
 


### PR DESCRIPTION
The config variable enable_frontedit_links doesn't work. It should be automatic_frontedit_links. 

<!-- What's in this pull request? -->
## Overview

 enable_frontedit_links should be automatic_frontedit_links wherever it appears in the documentation.

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
N/A

<!-- If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine-User-Guide

Thank you for contributing to the ExpressionEngine User Guide! -->
