### PR TITLE
Add username and scheme to redis cache drive config override

### DIFF
--- a/docs/general/system-configuration-overrides.md
+++ b/docs/general/system-configuration-overrides.md
@@ -2398,8 +2398,10 @@ Example Usage:
     $config['redis'] = array(
       'host' => '127.0.0.1',
       'password' => NULL,
+      'username' => NULL,
       'port' => 6379,
-      'timeout' => 0
+      'timeout' => 0,
+      'scheme' => 'tcp' // Use 'tls' for Auth connection(username & password required) 
     );
 
 ## `relaxed_track_views`

--- a/docs/general/system-configuration-overrides.md
+++ b/docs/general/system-configuration-overrides.md
@@ -2401,7 +2401,7 @@ Example Usage:
       'username' => NULL,
       'port' => 6379,
       'timeout' => 0,
-      'scheme' => 'tcp' // Use 'tls' for Auth connection(username & password required) 
+      'scheme' => NULL // Use 'tls' for Auth connection(username & password required) 
     );
 
 ## `relaxed_track_views`


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Introduce the new override values to enable Redis TLS and ACL Auth connections in Redis cache driver.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#5280](https://github.com/ExpressionEngine/ExpressionEngine/discussions/5280).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [x] 🛁 Rewrites existing documentation
- [ ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

## Related Application Change
<!-- Required when this is associated with an application pull request -->
Application Pull Request: https://github.com/ExpressionEngine/ExpressionEngine/pull/5281
